### PR TITLE
fix memory leak at flickcurl_invoke_photos_list()

### DIFF
--- a/src/photo.c
+++ b/src/photo.c
@@ -1324,6 +1324,7 @@ flickcurl_invoke_photos_list(flickcurl* fc, const xmlChar* xpathExpr,
   
     photos_list->photos = flickcurl_build_photos(fc, xpathCtx, photosXpathExpr,
                                                  &photos_list->photos_count);
+    free(photosXpathExpr);
     if(!photos_list->photos) {
       fc->failed = 1;
       goto tidy;


### PR DESCRIPTION
Hi dajobe.

I fixed memory leak at flickcurl_invoke_photos_list().
please merge this commit.

Best Regards.
