### PR TITLE
Remove old curl header include

### DIFF
--- a/src/flickcurl_internal.h
+++ b/src/flickcurl_internal.h
@@ -24,7 +24,6 @@
 #include <libxml/xpath.h>
 
 #include <curl/curl.h>
-#include <curl/types.h>
 #include <curl/easy.h>
 
 


### PR DESCRIPTION
Versions of curl >=7.21.7 don't include the types.h header file anymore and [upstream states](http://curl.haxx.se/mail/tracker-2011-07/0012.html) that it has been deprecated and blanked out for almost 7 years now.
