### PR TITLE
configure: Include <stdio.h> in vsnprintf check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -133,6 +133,7 @@ AC_LINK_IFELSE([AC_LANG_PROGRAM([[#ifdef HAVE_GETOPT_H
 if test $ac_cv_func_vsnprintf = yes; then
   AC_MSG_CHECKING(vsnprintf has C99 compatible return value)
   AC_RUN_IFELSE([AC_LANG_SOURCE([[#include <stdarg.h>
+#include <stdio.h>
 int is_c99(char *s, ...) {
   char buffer[32];
   va_list args;


### PR DESCRIPTION
Avoid implicit declaration of vsnprintf for improved C99 compatibility.  Otherwise the configure script will fail to detect vsnprintf support with future compilers which do not support implicit function declarations.

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
